### PR TITLE
Add automated schedule fetch and viewer

### DIFF
--- a/.github/workflows/update-schedule.yml
+++ b/.github/workflows/update-schedule.yml
@@ -1,0 +1,28 @@
+name: Update schedule
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Download schedule
+        env:
+          BARNIM_USER: schule
+          BARNIM_PASS: ${{ secrets.BARNIM_PASS }}
+        run: |
+          curl -L -u "$BARNIM_USER:$BARNIM_PASS" \
+            "https://www.barnim-gymnasium.de/fileadmin/schulen/barnim-gymnasium/Dokumente/Pl%C3%A4ne/splan.pdf" \
+            -o splan.pdf
+      - name: Commit changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add splan.pdf
+          git commit -m "Update schedule" || echo "No changes" 
+          git push

--- a/index.html
+++ b/index.html
@@ -2,66 +2,35 @@
 <html lang="de">
 <head>
     <meta charset="UTF-8">
-    <title>Wikipedia Suche</title>
+    <title>Stundenplan Klasse 7/6</title>
     <style>
         body {
             font-family: Arial, sans-serif;
-            max-width: 600px;
+            max-width: 900px;
             margin: 0 auto;
-            padding: 2em;
+            padding: 2rem;
         }
-        input[type="text"] {
-            width: 80%;
-            padding: 0.5em;
+        #plan {
+            width: 100%;
+            height: 800px;
+            border: none;
         }
         button {
-            padding: 0.5em;
-        }
-        #result {
-            margin-top: 1em;
+            padding: 0.5rem 1rem;
+            margin-top: 1rem;
         }
     </style>
 </head>
 <body>
-    <h1>Wikipedia Suche</h1>
-    <p>Gib einen Begriff ein und erhalte die Zusammenfassung aus Wikipedia.</p>
-    <input type="text" id="searchTerm" placeholder="Suchbegriff">
-    <button id="searchBtn">Suchen</button>
-    <div id="result"></div>
-
+    <h1>Stundenplan der Klasse 7/6</h1>
+    <iframe id="plan" src="splan.pdf"></iframe>
+    <div>
+        <button id="reload">Plan neu laden</button>
+    </div>
     <script>
-        async function searchWikipedia() {
-            const term = document.getElementById('searchTerm').value.trim();
-            if (!term) {
-                document.getElementById('result').innerHTML = '<p>Bitte einen Suchbegriff eingeben.</p>';
-                return;
-            }
-            document.getElementById('result').innerHTML = '<p>Suche...</p>';
-            try {
-                const response = await fetch(`https://de.wikipedia.org/api/rest_v1/page/summary/${encodeURIComponent(term)}`);
-                if (!response.ok) {
-                    throw new Error('Kein Ergebnis gefunden');
-                }
-                const data = await response.json();
-                if (data.extract) {
-                    document.getElementById('result').innerHTML = `
-                        <h2>${data.title}</h2>
-                        <p>${data.extract}</p>
-                        <p><a href="https://de.wikipedia.org/wiki/${encodeURIComponent(term)}" target="_blank">Mehr auf Wikipedia</a></p>
-                    `;
-                } else {
-                    document.getElementById('result').innerHTML = '<p>Kein Ergebnis gefunden.</p>';
-                }
-            } catch (error) {
-                document.getElementById('result').innerHTML = '<p>Fehler: ' + error.message + '</p>';
-            }
-        }
-
-        document.getElementById('searchBtn').addEventListener('click', searchWikipedia);
-        document.getElementById('searchTerm').addEventListener('keyup', function (event) {
-            if (event.key === 'Enter') {
-                searchWikipedia();
-            }
+        document.getElementById('reload').addEventListener('click', function() {
+            const frame = document.getElementById('plan');
+            frame.src = 'splan.pdf?t=' + new Date().getTime();
         });
     </script>
 </body>

--- a/splan.pdf
+++ b/splan.pdf
@@ -1,0 +1,68 @@
+%PDF-1.3
+% ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/Contents 7 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 6 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+4 0 obj
+<<
+/PageMode /UseNone /Pages 6 0 R /Type /Catalog
+>>
+endobj
+5 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20250605200811+00'00') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20250605200811+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+6 0 obj
+<<
+/Count 1 /Kids [ 3 0 R ] /Type /Pages
+>>
+endobj
+7 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 132
+>>
+stream
+GapQh0E=F,0U\H3T\pNYT^QKk?tc>IP,;W#U1^23ihPEM_?CZ51'*4N=m0!2`!rD0(`F5>R%#!BK]FUr"QUgTVe5#QUnebT"IGA8V535gj<Wl%.YM=]KP5on.W>CgH-..,~>endstream
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000073 00000 n 
+0000000104 00000 n 
+0000000211 00000 n 
+0000000414 00000 n 
+0000000482 00000 n 
+0000000778 00000 n 
+0000000837 00000 n 
+trailer
+<<
+/ID 
+[<f0098c0bcd598c47323754e385552d71><f0098c0bcd598c47323754e385552d71>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 5 0 R
+/Root 4 0 R
+/Size 8
+>>
+startxref
+1059
+%%EOF


### PR DESCRIPTION
## Summary
- replace example page with schedule viewer and reload button
- add GitHub Action to download the `splan.pdf` every morning at 6am
- include placeholder PDF so the page works without updates

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6841f8cca4b883319dbdd5c353d37eee